### PR TITLE
Introduces cmd ide clean for removing IDE files

### DIFF
--- a/cmd/ide.go
+++ b/cmd/ide.go
@@ -7,8 +7,8 @@ import (
 
 var ideCmd = &cobra.Command{
 	Use:   "ide",
-	Short: "Ide editor functionality",
-	Long:  `Ide editor functionality`,
+	Short: "IDE (editor) functionality",
+	Long:  `IDE (editor) functionality`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if err := EnableDebug(cmd); err != nil {
 			log.Fatalln(err)
@@ -18,8 +18,8 @@ var ideCmd = &cobra.Command{
 
 var ideCleanCmd = &cobra.Command{
 	Use:   "clean",
-	Short: "Removes IDE files like .idea and *.iml",
-	Long:  `Removes IDE files like .idea and *.iml`,
+	Short: "Removes IDE files and folders, e.g. .idea and *.iml",
+	Long:  `Removes IDE files and folders, e.g. .idea and *.iml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		report, err := file.CleanIntellijFiles(ctx.TargetDirectory, ctx.Recursive, ctx.DryRun)
 		if err != nil {
@@ -35,5 +35,5 @@ func init() {
 
 	ideCmd.PersistentFlags().BoolVarP(&ctx.Recursive, "recursive", "r", false, "turn on recursive mode")
 	ideCmd.PersistentFlags().StringVar(&ctx.TargetDirectory, "target", ".", "Optional target directory")
-	ideCmd.PersistentFlags().BoolVar(&ctx.DryRun, "dry-run", false, "dry run does not write to pom.xml")
+	ideCmd.PersistentFlags().BoolVar(&ctx.DryRun, "dry-run", false, "disables delete of files and folders")
 }

--- a/cmd/ide.go
+++ b/cmd/ide.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"co-pilot/pkg/file"
+	"github.com/spf13/cobra"
+)
+
+var ideCmd = &cobra.Command{
+	Use:   "ide",
+	Short: "Ide editor functionality",
+	Long:  `Ide editor functionality`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if err := EnableDebug(cmd); err != nil {
+			log.Fatalln(err)
+		}
+	},
+}
+
+var ideCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Removes IDE files like .idea and *.iml",
+	Long:  `Removes IDE files like .idea and *.iml`,
+	Run: func(cmd *cobra.Command, args []string) {
+		report, err := file.CleanIntellijFiles(ctx.TargetDirectory, ctx.Recursive, ctx.DryRun)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		log.Infof(report)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(ideCmd)
+	ideCmd.AddCommand(ideCleanCmd)
+
+	ideCmd.PersistentFlags().BoolVarP(&ctx.Recursive, "recursive", "r", false, "turn on recursive mode")
+	ideCmd.PersistentFlags().StringVar(&ctx.TargetDirectory, "target", ".", "Optional target directory")
+	ideCmd.PersistentFlags().BoolVar(&ctx.DryRun, "dry-run", false, "dry run does not write to pom.xml")
+}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -313,6 +313,10 @@ func Equal(fileA string, fileB string) (bool, error) {
 	return true, nil
 }
 
-func Delete(filePath string) error {
+func DeleteFile(filePath string) error {
 	return os.Remove(filePath)
+}
+
+func DeleteDirectory(dirPath string) error {
+	return os.RemoveAll(dirPath)
 }

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -313,10 +313,10 @@ func Equal(fileA string, fileB string) (bool, error) {
 	return true, nil
 }
 
-func DeleteFile(filePath string) error {
+func DeleteSingleFile(filePath string) error {
 	return os.Remove(filePath)
 }
 
-func DeleteDirectory(dirPath string) error {
+func DeleteAll(dirPath string) error {
 	return os.RemoveAll(dirPath)
 }

--- a/pkg/file/ide.go
+++ b/pkg/file/ide.go
@@ -1,0 +1,91 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+func CleanIntellijFiles(targetDir string, recursive bool, dryRun bool) (string, error) {
+	if recursive {
+		return cleanIntellijFiles(targetDir, dryRun)
+	} else {
+		return cleanIntellijFile(targetDir, dryRun)
+	}
+}
+
+func cleanIntellijFiles(targetDir string, dryRun bool) (string, error) {
+	var filesDeleted = 0
+	var dirsDeleted = 0
+
+	imlFiles, err := FindAll(".iml", []string{}, targetDir)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range imlFiles {
+		filesDeleted += 1
+		if err = logAndDelete(f, dryRun); err != nil {
+			return "", err
+		}
+	}
+
+	ideaDirs, err := FindAll(".idea", []string{}, targetDir)
+	if err != nil {
+		return "", err
+	}
+	for _, d := range ideaDirs {
+		dirsDeleted += 1
+		if err = logAndDelete(d, dryRun); err != nil {
+			return "", nil
+		}
+	}
+
+	if dryRun {
+		return fmt.Sprintf("Found %d files and %d directories to delete", filesDeleted, dirsDeleted), nil
+	} else {
+		return fmt.Sprintf("Deleted %d files and %d directories", filesDeleted, dirsDeleted), nil
+	}
+}
+
+func cleanIntellijFile(targetDir string, dryRun bool) (string, error) {
+	var imlFile = "not found"
+	var ideaDir = "not found"
+
+	files, err := ioutil.ReadDir(targetDir)
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range files {
+		if strings.Contains(f.Name(), ".iml") && !f.IsDir() {
+			fileName := Path("%s/%s", targetDir, f.Name())
+			imlFile = fileName
+			if err = logAndDelete(fileName, dryRun); err != nil {
+				return "", err
+			}
+		}
+		if strings.Contains(f.Name(), ".idea") && f.IsDir() {
+			dirName := Path("%s/%s", targetDir, f.Name())
+			ideaDir = dirName
+			if err = logAndDelete(dirName, dryRun); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return fmt.Sprintf("Iml file: %s, .idea dir: %s", imlFile, ideaDir), nil
+}
+
+func logAndDelete(fileName string, dryRun bool) error {
+	if dryRun {
+		log.Infof("Found .iml file: %s", fileName)
+	} else {
+		log.Infof("Deleting .iml file: %s", fileName)
+		err := DeleteDirectory(fileName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/file/ide.go
+++ b/pkg/file/ide.go
@@ -48,8 +48,8 @@ func cleanIntellijFiles(targetDir string, dryRun bool) (string, error) {
 }
 
 func cleanIntellijFile(targetDir string, dryRun bool) (string, error) {
-	var imlFile = "not found"
-	var ideaDir = "not found"
+	var filesDeleted = 0
+	var dirsDeleted = 0
 
 	files, err := ioutil.ReadDir(targetDir)
 	if err != nil {
@@ -58,22 +58,22 @@ func cleanIntellijFile(targetDir string, dryRun bool) (string, error) {
 
 	for _, f := range files {
 		if strings.Contains(f.Name(), ".iml") && !f.IsDir() {
+			filesDeleted += 1
 			fileName := Path("%s/%s", targetDir, f.Name())
-			imlFile = fileName
 			if err = logAndDelete(fileName, dryRun); err != nil {
 				return "", err
 			}
 		}
 		if strings.Contains(f.Name(), ".idea") && f.IsDir() {
+			dirsDeleted += 1
 			dirName := Path("%s/%s", targetDir, f.Name())
-			ideaDir = dirName
 			if err = logAndDelete(dirName, dryRun); err != nil {
 				return "", err
 			}
 		}
 	}
 
-	return fmt.Sprintf("Iml file: %s, .idea dir: %s", imlFile, ideaDir), nil
+	return fmt.Sprintf("Iml files: %d, .idea dirs: %d", filesDeleted, dirsDeleted), nil
 }
 
 func logAndDelete(fileName string, dryRun bool) error {
@@ -81,7 +81,7 @@ func logAndDelete(fileName string, dryRun bool) error {
 		log.Infof("Found .iml file: %s", fileName)
 	} else {
 		log.Infof("Deleting .iml file: %s", fileName)
-		err := DeleteDirectory(fileName)
+		err := DeleteAll(fileName)
 		if err != nil {
 			return err
 		}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -146,5 +146,5 @@ func renderAndDelete(targetPath string, targetConfig interface{}) error {
 	}
 
 	log.Infof("deleting old render file %s", targetPath)
-	return file.DeleteFile(targetPath)
+	return file.DeleteSingleFile(targetPath)
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -146,5 +146,5 @@ func renderAndDelete(targetPath string, targetConfig interface{}) error {
 	}
 
 	log.Infof("deleting old render file %s", targetPath)
-	return file.Delete(targetPath)
+	return file.DeleteFile(targetPath)
 }


### PR DESCRIPTION
```

   _____                  _ _       _
  / ____|                (_) |     | |
 | |     ___ ______ _ __  _| | ___ | |_
 | |    / _ \______| '_ \| | |/ _ \| __|
 | |___| (_) |     | |_) | | | (_) | |_
  \_____\___/      | .__/|_|_|\___/ \__|
                   | |
                   |_|
== version: v0.2.23, built: 2020-09-22 14:46 ==
Ide editor functionality

Usage:
  co-pilot ide [command]

Available Commands:
  clean       Removes IDE files like .idea and *.iml

Flags:
      --dry-run         dry run does not write to pom.xml
  -h, --help            help for ide
  -r, --recursive       turn on recursive mode
      --target string   Optional target directory (default ".")

Global Flags:
      --debug   turn on debug output

Use "co-pilot ide [command] --help" for more information about a command.

```